### PR TITLE
Removing some seemingly spurious (and broken) imports

### DIFF
--- a/CreateStateMachine.py
+++ b/CreateStateMachine.py
@@ -2,7 +2,6 @@
 
 import rospy
 import smach
-import smach_ros
 
 #import literally all the states we will ever have:
 from StateMachine.interact.interact_gate import *

--- a/StateMachine/sub.py
+++ b/StateMachine/sub.py
@@ -8,7 +8,6 @@ stored as global vars in gbl, and system data exposed through rospy API.
 '''
 import rospy
 import smach
-import smach_ros
 import math
 
 from std_msgs.msg import Float32MultiArray

--- a/test_smach.py
+++ b/test_smach.py
@@ -3,7 +3,6 @@
 #import roslib; roslib.load_manifest('smach_tutorials')
 import rospy
 import smach
-import smach_ros
 from StateMachine.search import search
 
 class Foo(smach.State):


### PR DESCRIPTION
The smach_ros module doesn't seem to exist after getting ROS setup (includng ros-kinetic-smach package). It breaks when I attempt running claiming it's missing this import. removing seems to fix issue, implying that the import did nothing (or it was likely monkey-patching something that is otherwise provided with the current stack). Please educate me if i'm incorrect, and point me to where it comes from so i can include in install.sh script. 